### PR TITLE
Support VS2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ https://marketplace.visualstudio.com/items?itemName=drewnoakes.SideScroller
 
 # Credits
 
-Icon by Juraj Sedlák from the [Noun Project](https://thenounproject.com/term/horizontal-scroll/1028300/), edited to be more VS-like in InkScape.
+Icon by Juraj Sedlák from the [Noun Project](https://thenounproject.com/icon/1028300/), edited to be more VS-like in [InkScape](https://inkscape.org/).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Visual Studio Marketplace Rating](http://vsmarketplacebadge.apphb.com/rating-star/drewnoakes.SideScroller.svg)](https://marketplace.visualstudio.com/items?itemName=drewnoakes.SideScroller)
 [![Visual Studio Marketplace Downloads](http://vsmarketplacebadge.apphb.com/downloads-short/drewnoakes.SideScroller.svg)](https://marketplace.visualstudio.com/items?itemName=drewnoakes.SideScroller)
 
-Enables horizontal scrolling by holding down the <kbd>Shift</kbd> key and spinning the mouse wheel in Visual Studio (2017, 2019 and later).
+Enables horizontal scrolling by holding down the <kbd>Shift</kbd> key and spinning the mouse wheel in Visual Studio (2017, 2019 and 2022).
 
 This feature is available in many other programs. Once you're used to it, it is sorely missed.
 

--- a/SideScroller.Vsix/SideScroller.Vsix.csproj
+++ b/SideScroller.Vsix/SideScroller.Vsix.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.16.9.1050\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.16.9.1050\build\Microsoft.VSSDK.BuildTools.props')" />
+  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.17.0.5232\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.17.0.5232\build\Microsoft.VSSDK.BuildTools.props')" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
@@ -104,12 +104,12 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.33\build\Microsoft.VisualStudio.SDK.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.33\build\Microsoft.VisualStudio.SDK.Analyzers.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.122\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.122\build\Microsoft.VisualStudio.Threading.Analyzers.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.16.9.1050\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.16.9.1050\build\Microsoft.VSSDK.BuildTools.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.16.9.1050\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.16.9.1050\build\Microsoft.VSSDK.BuildTools.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.17.0.5232\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.17.0.5232\build\Microsoft.VSSDK.BuildTools.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.17.0.5232\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.17.0.5232\build\Microsoft.VSSDK.BuildTools.targets'))" />
   </Target>
   <Import Project="..\packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.33\build\Microsoft.VisualStudio.SDK.Analyzers.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.33\build\Microsoft.VisualStudio.SDK.Analyzers.targets')" />
   <Import Project="..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.122\build\Microsoft.VisualStudio.Threading.Analyzers.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.122\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" />
-  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.16.9.1050\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.16.9.1050\build\Microsoft.VSSDK.BuildTools.targets')" />
+  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.17.0.5232\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.17.0.5232\build\Microsoft.VSSDK.BuildTools.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/SideScroller.Vsix/packages.config
+++ b/SideScroller.Vsix/packages.config
@@ -7,5 +7,5 @@
   <package id="Microsoft.VisualStudio.Text.UI" version="15.0.26228" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Text.UI.Wpf" version="15.0.26228" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Threading.Analyzers" version="15.8.122" targetFramework="net461" />
-  <package id="Microsoft.VSSDK.BuildTools" version="16.9.1050" targetFramework="net461" developmentDependency="true" />
+  <package id="Microsoft.VSSDK.BuildTools" version="17.0.5232" targetFramework="net461" developmentDependency="true" />
 </packages>

--- a/SideScroller.Vsix/source.extension.vsixmanifest
+++ b/SideScroller.Vsix/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="SideScroller.Vsix.d0f12930-4bcc-455c-b681-f765aaab3d6f" Version="1.1" Language="en-US" Publisher="Drew Noakes" />
+    <Identity Id="SideScroller.Vsix.d0f12930-4bcc-455c-b681-f765aaab3d6f" Version="1.2" Language="en-US" Publisher="Drew Noakes" />
     <DisplayName>SideScroller</DisplayName>
     <Description xml:space="preserve">Scroll horizontally with the mouse wheel when holding the shift key.</Description>
     <MoreInfo>https://github.com/drewnoakes/vs-side-scroller</MoreInfo>
@@ -11,7 +11,12 @@
     <Tags>scroll, shift, horizontal scroll, mouse wheel</Tags>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,)" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0, 17.0)">
+      <ProductArchitecture>x86</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, )">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
Fixes #6

This bumps the version to 1.2.

Thankfully it appears that we can use a single VSIX for VS2022 and earlier versions. Most documentation and other examples suggest this isn't (easily) possible. In the worst case, if this causes issues, we'll have to create separate extensions for 32/64 bit versions of VS.